### PR TITLE
【課題1】ポケモンデータを表示するカスタムセルの実装

### DIFF
--- a/PokeChallenge01.xcodeproj/project.pbxproj
+++ b/PokeChallenge01.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		3DA73E442913E81800F3D3FC /* PokeChallenge01UITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DA73E432913E81800F3D3FC /* PokeChallenge01UITestsLaunchTests.swift */; };
 		3DA73E542913FB1B00F3D3FC /* DummyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DA73E522913FB1B00F3D3FC /* DummyTableViewCell.swift */; };
 		3DA73E552913FB1B00F3D3FC /* DummyTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3DA73E532913FB1B00F3D3FC /* DummyTableViewCell.xib */; };
+		D65D2733293CD203007AB3F8 /* PokeTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65D2732293CD203007AB3F8 /* PokeTableViewCell.swift */; };
+		D65D2735293CD20C007AB3F8 /* PokeTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D65D2734293CD20C007AB3F8 /* PokeTableViewCell.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,6 +69,8 @@
 		3DA73E432913E81800F3D3FC /* PokeChallenge01UITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokeChallenge01UITestsLaunchTests.swift; sourceTree = "<group>"; };
 		3DA73E522913FB1B00F3D3FC /* DummyTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyTableViewCell.swift; sourceTree = "<group>"; };
 		3DA73E532913FB1B00F3D3FC /* DummyTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DummyTableViewCell.xib; sourceTree = "<group>"; };
+		D65D2732293CD203007AB3F8 /* PokeTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PokeTableViewCell.swift; sourceTree = "<group>"; };
+		D65D2734293CD20C007AB3F8 /* PokeTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PokeTableViewCell.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -195,6 +199,8 @@
 		3DA73E512913FAC800F3D3FC /* View */ = {
 			isa = PBXGroup;
 			children = (
+				D65D2732293CD203007AB3F8 /* PokeTableViewCell.swift */,
+				D65D2734293CD20C007AB3F8 /* PokeTableViewCell.xib */,
 				3DA73E522913FB1B00F3D3FC /* DummyTableViewCell.swift */,
 				3DA73E532913FB1B00F3D3FC /* DummyTableViewCell.xib */,
 			);
@@ -314,6 +320,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D65D2735293CD20C007AB3F8 /* PokeTableViewCell.xib in Resources */,
 				3DA73E2D2913E81700F3D3FC /* LaunchScreen.storyboard in Resources */,
 				3DA73E2A2913E81700F3D3FC /* Assets.xcassets in Resources */,
 				3DA73E552913FB1B00F3D3FC /* DummyTableViewCell.xib in Resources */,
@@ -352,6 +359,7 @@
 				3D5B24ED2914059B0007726B /* UITableView+Extension.swift in Sources */,
 				3D39FC562915064300407530 /* PokeRepository.swift in Sources */,
 				3DA73E542913FB1B00F3D3FC /* DummyTableViewCell.swift in Sources */,
+				D65D2733293CD203007AB3F8 /* PokeTableViewCell.swift in Sources */,
 				3DA73E232913E81700F3D3FC /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PokeChallenge01/View/PokeTableViewCell.swift
+++ b/PokeChallenge01/View/PokeTableViewCell.swift
@@ -1,0 +1,36 @@
+//
+//  PokeTableViewCell.swift
+//  PokeChallenge01
+//
+//  Created by Sugiyama Yuta on 2022/11/28.
+//
+
+import UIKit
+
+final class PokeTableViewCell: UITableViewCell {
+    
+    
+    @IBOutlet private var numberLabel: UILabel!
+    @IBOutlet private var titleLabel: UILabel!
+    @IBOutlet private var hpLabel: UILabel!
+    @IBOutlet private var attackLabel: UILabel!
+    @IBOutlet private var defenseLabel: UILabel!
+    @IBOutlet private var specialDefenseLabel: UILabel!
+    @IBOutlet private var speedLabel: UILabel!
+    
+    @IBOutlet private var pokeView: UIImageView!
+    
+    @IBOutlet private var specialAttackLabel: UILabel!
+    
+    func configure(pokemon: Pokemon) {
+        numberLabel.text = "No: \(pokemon.id)"
+        titleLabel.text = pokemon.name.japanese
+        hpLabel.text = "HP \(pokemon.status.hp)"
+        attackLabel.text = "こうげき \(pokemon.status.attack)"
+        defenseLabel.text = "ぼうぎょ \(pokemon.status.defense)"
+        specialAttackLabel.text = "とくこう \(pokemon.status.specialAttack)"
+        specialDefenseLabel.text = "とくぼう \(pokemon.status.specialDefense)"
+        speedLabel.text = "すばやさ \(pokemon.status.speed)"
+    }
+    
+}

--- a/PokeChallenge01/View/PokeTableViewCell.xib
+++ b/PokeChallenge01/View/PokeTableViewCell.xib
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="123" id="KGk-i7-Jjw" customClass="PokeTableViewCell" customModule="PokeChallenge01" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="239" height="123"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="239" height="123"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bNH-dD-6eW">
+                        <rect key="frame" x="20.000000000000007" y="7.9999999999999982" width="96.666666666666686" height="20.333333333333329"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MNh-zR-Bqx">
+                                <rect key="frame" x="0.0" y="0.0" width="44.333333333333336" height="20.333333333333332"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uwf-pK-39p">
+                                <rect key="frame" x="52.333333333333329" y="0.0" width="44.333333333333329" height="20.333333333333332"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="uwf-pK-39p" firstAttribute="leading" secondItem="MNh-zR-Bqx" secondAttribute="trailing" constant="8" id="s2f-XX-hqJ"/>
+                        </constraints>
+                    </stackView>
+                    <stackView opaque="NO" contentMode="scaleToFill" spacing="53" translatesAutoresizingMaskIntoConstraints="NO" id="M6B-6x-M8M">
+                        <rect key="frame" x="20" y="33.333333333333343" width="178.66666666666666" height="80"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hyo-1O-Hla">
+                                <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="80" id="J4H-Us-ZrD"/>
+                                    <constraint firstAttribute="width" constant="80" id="gpH-II-qeJ"/>
+                                </constraints>
+                            </imageView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="m8Y-3x-4hQ">
+                                <rect key="frame" x="88" y="0.0" width="41.333333333333343" height="80"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="qxc-0T-D2v">
+                                        <rect key="frame" x="0.0" y="0.0" width="41.333333333333336" height="20.333333333333332"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="4dQ-1k-hwi">
+                                        <rect key="frame" x="0.0" y="28.333333333333329" width="41.333333333333336" height="20.333333333333329"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Jq8-3k-w2x">
+                                        <rect key="frame" x="0.0" y="56.666666666666664" width="41.333333333333336" height="23.333333333333336"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="Jq8-3k-w2x" firstAttribute="top" secondItem="4dQ-1k-hwi" secondAttribute="bottom" constant="8" id="kcw-UR-hIG"/>
+                                    <constraint firstItem="4dQ-1k-hwi" firstAttribute="top" secondItem="qxc-0T-D2v" secondAttribute="bottom" constant="8" id="wmf-Cu-x2i"/>
+                                </constraints>
+                            </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="dbr-Ew-jZk">
+                                <rect key="frame" x="137.33333333333334" y="0.0" width="41.333333333333343" height="80"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="hU9-DS-vt6">
+                                        <rect key="frame" x="0.0" y="0.0" width="41.333333333333336" height="20.333333333333332"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="4zv-sv-3jq">
+                                        <rect key="frame" x="0.0" y="28.333333333333329" width="41.333333333333336" height="20.333333333333329"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bb1-s4-w4o">
+                                        <rect key="frame" x="0.0" y="56.666666666666664" width="41.333333333333336" height="23.333333333333336"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="bb1-s4-w4o" firstAttribute="top" secondItem="4zv-sv-3jq" secondAttribute="bottom" constant="8" id="BjU-2V-mGN"/>
+                                    <constraint firstItem="4zv-sv-3jq" firstAttribute="top" secondItem="hU9-DS-vt6" secondAttribute="bottom" constant="8" id="QsI-CT-FN4"/>
+                                </constraints>
+                            </stackView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="dbr-Ew-jZk" secondAttribute="trailing" id="5Ed-e5-Aug"/>
+                            <constraint firstItem="m8Y-3x-4hQ" firstAttribute="leading" secondItem="Hyo-1O-Hla" secondAttribute="trailing" constant="8" id="9OW-xQ-T89"/>
+                            <constraint firstItem="dbr-Ew-jZk" firstAttribute="top" secondItem="M6B-6x-M8M" secondAttribute="top" id="EcG-Sa-x1s"/>
+                            <constraint firstAttribute="bottom" secondItem="m8Y-3x-4hQ" secondAttribute="bottom" id="LsZ-Eg-BCu"/>
+                            <constraint firstItem="Hyo-1O-Hla" firstAttribute="top" secondItem="M6B-6x-M8M" secondAttribute="top" id="bzI-6q-LnK"/>
+                            <constraint firstItem="m8Y-3x-4hQ" firstAttribute="top" secondItem="M6B-6x-M8M" secondAttribute="top" id="iLt-Zf-vjx"/>
+                            <constraint firstAttribute="bottom" secondItem="dbr-Ew-jZk" secondAttribute="bottom" id="t1q-K1-9Ie"/>
+                            <constraint firstAttribute="bottom" secondItem="Hyo-1O-Hla" secondAttribute="bottom" id="tXz-DT-5Lz"/>
+                            <constraint firstItem="dbr-Ew-jZk" firstAttribute="leading" secondItem="m8Y-3x-4hQ" secondAttribute="trailing" constant="8" id="wcY-Lg-1Fq"/>
+                        </constraints>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="M6B-6x-M8M" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" id="51r-rw-T9Y"/>
+                    <constraint firstItem="M6B-6x-M8M" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="33.329999999999998" id="TVQ-AS-JR9"/>
+                    <constraint firstAttribute="bottom" secondItem="M6B-6x-M8M" secondAttribute="bottom" constant="5" id="UDs-VB-TAN"/>
+                    <constraint firstItem="M6B-6x-M8M" firstAttribute="top" secondItem="bNH-dD-6eW" secondAttribute="bottom" constant="5" id="kiV-lO-iQ8"/>
+                    <constraint firstItem="bNH-dD-6eW" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" id="nmf-Tg-Lih"/>
+                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="M6B-6x-M8M" secondAttribute="trailing" constant="20" id="r9E-7F-I1F"/>
+                    <constraint firstItem="bNH-dD-6eW" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="v3w-nY-0aL"/>
+                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bNH-dD-6eW" secondAttribute="trailing" constant="20" id="vXr-TS-Kyt"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="attackLabel" destination="4dQ-1k-hwi" id="GG5-QC-bqe"/>
+                <outlet property="defenseLabel" destination="Jq8-3k-w2x" id="AHp-kc-IE5"/>
+                <outlet property="hpLabel" destination="qxc-0T-D2v" id="LKL-HQ-qZC"/>
+                <outlet property="numberLabel" destination="MNh-zR-Bqx" id="0X7-nr-rth"/>
+                <outlet property="pokeView" destination="Hyo-1O-Hla" id="6tq-HU-xDB"/>
+                <outlet property="specialAttackLabel" destination="hU9-DS-vt6" id="oqL-Jf-VEr"/>
+                <outlet property="specialDefenseLabel" destination="4zv-sv-3jq" id="LRQ-9S-5RD"/>
+                <outlet property="speedLabel" destination="bb1-s4-w4o" id="bQp-52-lBp"/>
+                <outlet property="titleLabel" destination="uwf-pK-39p" id="p63-yq-dGq"/>
+            </connections>
+            <point key="canvasLocation" x="188.55140186915887" y="126.67386609071275"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/PokeChallenge01/View/PokeTableViewCell.xib
+++ b/PokeChallenge01/View/PokeTableViewCell.xib
@@ -17,8 +17,8 @@
                 <rect key="frame" x="0.0" y="0.0" width="239" height="123"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bNH-dD-6eW">
-                        <rect key="frame" x="20.000000000000007" y="7.9999999999999982" width="96.666666666666686" height="20.333333333333329"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="bNH-dD-6eW">
+                        <rect key="frame" x="20.000000000000007" y="7.9999999999999982" width="103.66666666666669" height="20.333333333333329"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MNh-zR-Bqx">
                                 <rect key="frame" x="0.0" y="0.0" width="44.333333333333336" height="20.333333333333332"/>
@@ -27,15 +27,12 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uwf-pK-39p">
-                                <rect key="frame" x="52.333333333333329" y="0.0" width="44.333333333333329" height="20.333333333333332"/>
+                                <rect key="frame" x="59.333333333333329" y="0.0" width="44.333333333333329" height="20.333333333333332"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <constraints>
-                            <constraint firstItem="uwf-pK-39p" firstAttribute="leading" secondItem="MNh-zR-Bqx" secondAttribute="trailing" constant="8" id="s2f-XX-hqJ"/>
-                        </constraints>
                     </stackView>
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="53" translatesAutoresizingMaskIntoConstraints="NO" id="M6B-6x-M8M">
                         <rect key="frame" x="20" y="33.333333333333343" width="178.66666666666666" height="80"/>
@@ -47,7 +44,7 @@
                                     <constraint firstAttribute="width" constant="80" id="gpH-II-qeJ"/>
                                 </constraints>
                             </imageView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="m8Y-3x-4hQ">
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="m8Y-3x-4hQ">
                                 <rect key="frame" x="88" y="0.0" width="41.333333333333343" height="80"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="qxc-0T-D2v">
@@ -69,12 +66,8 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstItem="Jq8-3k-w2x" firstAttribute="top" secondItem="4dQ-1k-hwi" secondAttribute="bottom" constant="8" id="kcw-UR-hIG"/>
-                                    <constraint firstItem="4dQ-1k-hwi" firstAttribute="top" secondItem="qxc-0T-D2v" secondAttribute="bottom" constant="8" id="wmf-Cu-x2i"/>
-                                </constraints>
                             </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="dbr-Ew-jZk">
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dbr-Ew-jZk">
                                 <rect key="frame" x="137.33333333333334" y="0.0" width="41.333333333333343" height="80"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="hU9-DS-vt6">
@@ -96,10 +89,6 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstItem="bb1-s4-w4o" firstAttribute="top" secondItem="4zv-sv-3jq" secondAttribute="bottom" constant="8" id="BjU-2V-mGN"/>
-                                    <constraint firstItem="4zv-sv-3jq" firstAttribute="top" secondItem="hU9-DS-vt6" secondAttribute="bottom" constant="8" id="QsI-CT-FN4"/>
-                                </constraints>
                             </stackView>
                         </subviews>
                         <constraints>

--- a/PokeChallenge01/ViewController/PokeListViewController.swift
+++ b/PokeChallenge01/ViewController/PokeListViewController.swift
@@ -15,7 +15,7 @@ final class PokeListViewController: UIViewController {
         didSet {
             tableview.delegate = self
             tableview.dataSource = self
-            tableview.register(DummyTableViewCell.self)
+            tableview.register(PokeTableViewCell.self)
         }
     }
 
@@ -50,7 +50,7 @@ extension PokeListViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(DummyTableViewCell.self, for: indexPath)
+        let cell = tableView.dequeueReusableCell(PokeTableViewCell.self, for: indexPath)
         cell.configure(pokemon: model.pokemons[indexPath.row])
         return cell
     }


### PR DESCRIPTION
## Issues
https://github.com/y-sugiyama654/PokeChallenge01/issues/1

## 概要

- 【xib】【課題1】InterfaceBuilderを使ってカスタムセルを実装

## やりたいこと

- [x] No、名前、各ステータスをデザイン通りに表示する
　・テキストはUILabelクラスを使用する
　・画像はUIImageViewクラスを使用する
- [x] StackViewを使用する
- [x] XIBファイルでレイアウトを組む
- [x] データは既にPokemonという命名で用意されているためそれを使用する
- [x] デザインは課題1を参考にする

## エビデンス
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-11-29 at 01 58 15](https://user-images.githubusercontent.com/42257182/204341203-5fb9bd9a-6cef-43b3-9c5b-698818335454.png)
ンス

![スクリーンショット 2022-11-29 2 27 53](https://user-images.githubusercontent.com/42257182/204342382-c47caf12-21b6-4b82-91dd-8469f771ce19.png)

